### PR TITLE
Support terraform's AWS provider version 2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ data "aws_region" "current" {}
 data "aws_availability_zones" "current" {}
 data "aws_ami" "amazonlinux" {
   most_recent = true
+  owners = ["amazon"]
 
   filter {
     name   = "owner-alias"


### PR DESCRIPTION
Adds owners parameter to aws_ami resource. This is now required for version 2 of the AWS provider. It also works in version 1. https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#data-source-aws_ami